### PR TITLE
Corrected the link to the Github page of the Carbonpaws assets list

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ CarbonPaws DEX on EnergyWeb
 
 ### Whitelisting
 
-Whitelisting requests are submited under [carbonpaws-tokenlist](https://github.com/carbonpawsio/carbonpaws-tokenlist) repository.
+Whitelisting requests are submited under [carbonpaws-tokenlist](https://github.com/EWDOGE/assets) repository.


### PR DESCRIPTION
The link was: https://github.com/carbonpawsio/carbonpaws-tokenlist
but this doesn't lead to any page.
It should be: https://github.com/EWDOGE/assets